### PR TITLE
fix: adds missing await keyword

### DIFF
--- a/custom_components/slack_user/__init__.py
+++ b/custom_components/slack_user/__init__.py
@@ -13,7 +13,7 @@ async def async_setup_entry(hass, entry):
     """Set up Slack User Entry."""
     for component in COMPONENT_TYPES:
         hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
+            await hass.config_entries.async_forward_entry_setup(entry, component)
         )
 
     return True


### PR DESCRIPTION
Detected code that calls async_forward_entry_setup for integration slack_user with title: [REDACTED] and entry_id: [REDACTED], during setup without awaiting async_forward_entry_setup, which can cause the setup lock to be released before the setup is done. This will stop working in Home Assistant 2025.1. Please report this issue.